### PR TITLE
Material CSS primary color contrast tweaks

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -1,6 +1,12 @@
 @import '@angular/material/theming';
 
-$primary: mat-palette($mat-green);
+$custom-mat-green: map-merge($mat-green, (
+  contrast: map-merge(map-get($mat-green, contrast), (
+    500: $light-primary-text
+  ))
+));
+
+$primary: mat-palette($custom-mat-green);
 $accent: mat-palette($mat-amber);
 $warn: mat-palette($mat-deep-orange);
 

--- a/src/app/components/bottom-bar/bottom-bar.component.scss
+++ b/src/app/components/bottom-bar/bottom-bar.component.scss
@@ -9,6 +9,7 @@
   height: 64px;
   width: 100%;
   background-color: mat-color($primary);
+  color: mat-color($primary, default-contrast);
   display: flex;
   flex-direction: row;
 

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -9,13 +9,13 @@
     <mat-card>
       <mat-card-title>Join a session</mat-card-title>
       <mat-card-actions align="end">
-        <button fxFlex mat-raised-button routerLink="/play" color="accent">Play</button>
+        <button fxFlex mat-raised-button routerLink="/play" color="primary">Play</button>
       </mat-card-actions>
     </mat-card>
     <mat-card>
       <mat-card-title>Host a session</mat-card-title>
       <mat-card-actions align="end">
-        <button fxFlex mat-stroked-button routerLink="/host">Host</button>
+        <button fxFlex mat-raised-button routerLink="/host" color="accent">Host</button>
       </mat-card-actions>
     </mat-card>
   </div>


### PR DESCRIPTION
This changes the 500 hue contrast color for our primary mat-green color from black to white. This means that text and icons that appear on the primary color will be white rather than black. This also changes the appearance of the homes page buttons as seen below:

![localhost_4200_(Laptop with MDPI screen) (1)](https://user-images.githubusercontent.com/1300395/89951754-9add0a00-dbf1-11ea-82c6-938d7c177bd0.png)
