### PR TITLE
Add a Firebase Tests badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@
 
 # Buzz About
 
-[![Build Status][Angular Tests badge]][Angular Tests page]
+[![Angular Build Status][Angular Tests badge]][Angular Tests page]
+[![Firebase Build Status][Firebase Tests badge]][Firebase Tests page]
 [![Deployment Status][Deploy badge]][Deploy page]
 
 </div align="center">
@@ -37,6 +38,8 @@ The Trust Fund is a permanent fund constitutionally established by the citizens 
 
 [Angular Tests badge]: ../../workflows/Angular%20Tests/badge.svg
 [Angular Tests page]: ../../actions?query=workflow%3A"Angular+Tests"
+[Firebase Tests badge]: ../../workflows/Firebase%20Tests/badge.svg
+[Firebase Tests page]: ../../actions?query=workflow%3A"Firebase+Tests"
 [Deploy badge]: ../../workflows/Firebase%20Deploy/badge.svg
 [Deploy page]: ../../actions?query=workflow%3A"Firebase+Deploy"
 [Angular]: https://angular.io/


### PR DESCRIPTION
The new tests—the ones for the Firebase security rules—didn't have a little indicator badge on the README, like the rest of our tests do, so I added one real quick :upside_down_face: It's a bit of a frill, but if the tests ever fail, it's helpful to see that in as many places as possible.