### PR TITLE
Fix a bug where all Cypress/Mocha/Chai types were getting imported into app code.

### DIFF
--- a/no-types.d.ts
+++ b/no-types.d.ts
@@ -1,0 +1,9 @@
+/**
+ * This is a type declaration file that doesn't declare anything. It's useful
+ * for 'masking' certain types that you don't want to include in your project.
+ *
+ * For example, if there's a certain library that you don't want to be typed,
+ * you can tell TypeScript to use this definition file for it instead.
+ *
+ * See: https://github.com/microsoft/TypeScript/issues/17042#issuecomment-317589758
+ */

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -10,5 +10,10 @@
   ],
   "include": [
     "src/**/*.d.ts"
-  ]
+  ],
+  "paths": {
+    "cypress": [
+      "no-types.d.ts"
+    ]
+  }
 }

--- a/tsconfig.spec.json
+++ b/tsconfig.spec.json
@@ -14,5 +14,10 @@
   "include": [
     "src/**/*.spec.ts",
     "src/**/*.d.ts"
-  ]
+  ],
+  "paths": {
+    "cypress": [
+      "no-types.d.ts"
+    ]
+  }
 }


### PR DESCRIPTION
Previously, Cypress's types were declared in a .d.ts file in
node_modules, which TypeScript is set up to read from automatically. For
most packages, this wouldn't a problem, since the types would have been
namespaced--you wouldn't actually see them unless you import that
package.

However, Cypress includes Chai and Mocha, which dump their types
directly into the global namespace. This is fine for the E2E tests, but
when we're just writing regular app code, we don't want TypeScript to
think that `expect` and `Assertion` and `it` are defined. (Because they
aren't! 🙃)

This is a particularly bad problem in the `.spec.ts` files, where Chai
and Jasmine are duking it out for control of the global namespace.

Cats and dogs, living together!

We can fix this problem by modifying the `tsconfig.app.json` and
`tsconfig.spec.json` files. These files govern the app code and Karma
tests, respectively, and we can tell them to ignore types coming from
Cypress.

This is still a bit tricky, though, because TypeScript doesn't actually
provide a way to exclude type declarations--there's an 'rule-in' list, but
no 'rule-out' list.

So, instead, for the app code and Karma tests, we provide an *alternate*
`.d.ts` file for Cypress to use--one that's entirely blank. That way, in
the app code an Karma tests, Cypress won't export any types.

See the links below for more information! 🙂

- <https://github.com/microsoft/TypeScript/issues/17042#issuecomment-317589758>
- <https://www.typescriptlang.org/docs/handbook/module-resolution.html#path-mapping>