### PR TITLE
Import 'firebase/auth' in auth.service.ts

### DIFF
--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -4,7 +4,7 @@ import { switchMap, map, shareReplay } from 'rxjs/operators';
 import { from, of, Observable } from 'rxjs';
 
 // Make sure that firebase/auth is included in the main bundle
-// (not lazy-loaded).
+// (not lazy-loaded, because relying on it to lazy-load was not working)
 import 'firebase/auth';
 
 @Injectable({

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -2,6 +2,9 @@ import { Injectable } from '@angular/core';
 import { AngularFireAuth } from '@angular/fire/auth';
 import { switchMap, map, shareReplay } from 'rxjs/operators';
 import { from, of, Observable } from 'rxjs';
+
+// Make sure that firebase/auth is included in the main bundle
+// (not lazy-loaded).
 import 'firebase/auth';
 
 @Injectable({

--- a/src/app/services/auth.service.ts
+++ b/src/app/services/auth.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
 import { AngularFireAuth } from '@angular/fire/auth';
-import { FirebaseService } from './firebase.service';
 import { switchMap, map, shareReplay } from 'rxjs/operators';
 import { from, of, Observable } from 'rxjs';
+import 'firebase/auth';
 
 @Injectable({
   providedIn: 'root'
@@ -10,7 +10,7 @@ import { from, of, Observable } from 'rxjs';
 export class AuthService {
 
 
-  constructor(private auth: AngularFireAuth, private firebaseService: FirebaseService) { }
+  constructor(private auth: AngularFireAuth) {}
 
   /**
    * Observable that emits the currently logged in firebase.User.


### PR DESCRIPTION
This fixes the auth issues we were having during play testing by forcing it to bundle `firebase/auth` into the main bundle so it is always loaded when we need it for firestore operations.