### PR TITLE
Prevent pull-to-refresh gesture

### DIFF
--- a/src/styles.scss
+++ b/src/styles.scss
@@ -22,6 +22,9 @@ html {
 body {
   margin: 0;
   height: 100%;
+
+  // Disables pull-to-refresh but allows overscroll glow effects.
+  overscroll-behavior-y: contain;
 }
 
 .main-content {


### PR DESCRIPTION
This prevents the pull-to-refresh gesture on Android while still allowing the overscroll glow animation. This CSS feature isn't available on iOS yet so it has no effect there even if we wanted to disable some of the overscroll bounciness on iOS.