### PR TITLE
Integrate the compatibility between bees and flowers into the gameplay

### DIFF
--- a/firestore-tests/src/rounds.spec.ts
+++ b/firestore-tests/src/rounds.spec.ts
@@ -139,7 +139,8 @@ describe('Rounds', () => {
         userId: 'bob',
         timePeriod: 22,
         barcodeValue: 12,
-        isNest: false
+        isNest: false,
+        incompatibleFlower: false
       });
       await firebase.assertSucceeds(alice.doc(doc.path).get());
       await firebase.assertSucceeds(bob.doc(doc.path).get());
@@ -153,37 +154,43 @@ describe('Rounds', () => {
         userId: 'bob',
         timePeriod: 22,
         barcodeValue: 12,
-        isNest: false
+        isNest: false,
+        incompatibleFlower: false
       }));
       await firebase.assertFails(addInteraction(alice, round.path, {
         userId: 'alice',
         timePeriod: 22,
         barcodeValue: 12,
-        isNest: false
+        isNest: false,
+        incompatibleFlower: false
       }));
       await firebase.assertFails(addInteraction(otherUser, round.path, {
         userId: 'otheruser',
         timePeriod: 22,
         barcodeValue: 12,
-        isNest: false
+        isNest: false,
+        incompatibleFlower: false
       }));
       await firebase.assertFails(addInteraction(otherUser, round.path, {
         userId: 'bob',
         timePeriod: 22,
         barcodeValue: 12,
-        isNest: false
+        isNest: false,
+        incompatibleFlower: false
       }));
       await firebase.assertFails(addInteraction(noAuth, round.path, {
         userId: 'bob',
         timePeriod: 22,
         barcodeValue: 12,
-        isNest: false
+        isNest: false,
+        incompatibleFlower: false
       }));
       await firebase.assertFails(addInteraction(noAuth, round.path, {
         userId: null,
         timePeriod: 22,
         barcodeValue: 12,
-        isNest: false
+        isNest: false,
+        incompatibleFlower: false
       }));
     });
 
@@ -192,13 +199,15 @@ describe('Rounds', () => {
         userId: 'carol',
         timePeriod: 22,
         barcodeValue: 12,
-        isNest: false
+        isNest: false,
+        incompatibleFlower: false
       }));
       await firebase.assertFails(addInteraction(carol, round.path, {
         userId: 'bob',
         timePeriod: 22,
         barcodeValue: 12,
-        isNest: false
+        isNest: false,
+        incompatibleFlower: false
       }));
     });
 
@@ -207,7 +216,8 @@ describe('Rounds', () => {
         userId: 'bob',
         timePeriod: 22,
         barcodeValue: 12,
-        isNest: false
+        isNest: false,
+        incompatibleFlower: false
       });
       await firebase.assertFails(alice.doc(doc.path).delete());
       await firebase.assertFails(bob.doc(doc.path).delete());
@@ -221,7 +231,8 @@ describe('Rounds', () => {
         userId: 'bob',
         timePeriod: 22,
         barcodeValue: 12,
-        isNest: false
+        isNest: false,
+        incompatibleFlower: false
       });
       await firebase.assertFails(alice.doc(doc.path).update({timePeriod: 23}));
       await firebase.assertFails(bob.doc(doc.path).update({timePeriod: 12}));

--- a/firestore-tests/src/rounds.spec.ts
+++ b/firestore-tests/src/rounds.spec.ts
@@ -124,6 +124,12 @@ describe('Rounds', () => {
 
   describe('Interactions', () => {
     let round;
+    let commonInteractionData =  {
+      timePeriod: 22,
+      barcodeValue: 12,
+      isNest: false,
+      incompatibleFlower: false
+    };
 
     beforeEach(async () => {
       await addStudentToSession(admin, 'carol', session.id, {
@@ -137,10 +143,7 @@ describe('Rounds', () => {
     it('can only be read by the teacher and the student who made the interaction', async () => {
       const doc = await addInteraction(admin, round.path, {
         userId: 'bob',
-        timePeriod: 22,
-        barcodeValue: 12,
-        isNest: false,
-        incompatibleFlower: false
+        ...commonInteractionData
       });
       await firebase.assertSucceeds(alice.doc(doc.path).get());
       await firebase.assertSucceeds(bob.doc(doc.path).get());
@@ -152,72 +155,45 @@ describe('Rounds', () => {
     it('can only be added to the round if you\'re a student', async () => {
       await firebase.assertSucceeds(addInteraction(bob, round.path, {
         userId: 'bob',
-        timePeriod: 22,
-        barcodeValue: 12,
-        isNest: false,
-        incompatibleFlower: false
+        ...commonInteractionData
       }));
       await firebase.assertFails(addInteraction(alice, round.path, {
         userId: 'alice',
-        timePeriod: 22,
-        barcodeValue: 12,
-        isNest: false,
-        incompatibleFlower: false
+        ...commonInteractionData
       }));
       await firebase.assertFails(addInteraction(otherUser, round.path, {
         userId: 'otheruser',
-        timePeriod: 22,
-        barcodeValue: 12,
-        isNest: false,
-        incompatibleFlower: false
+        ...commonInteractionData
       }));
       await firebase.assertFails(addInteraction(otherUser, round.path, {
         userId: 'bob',
-        timePeriod: 22,
-        barcodeValue: 12,
-        isNest: false,
-        incompatibleFlower: false
+        ...commonInteractionData
       }));
       await firebase.assertFails(addInteraction(noAuth, round.path, {
         userId: 'bob',
-        timePeriod: 22,
-        barcodeValue: 12,
-        isNest: false,
-        incompatibleFlower: false
+        ...commonInteractionData
       }));
       await firebase.assertFails(addInteraction(noAuth, round.path, {
         userId: null,
-        timePeriod: 22,
-        barcodeValue: 12,
-        isNest: false,
-        incompatibleFlower: false
+        ...commonInteractionData
       }));
     });
 
     it('can only be added if the userId matches', async () => {
       await firebase.assertSucceeds(addInteraction(carol, round.path, {
         userId: 'carol',
-        timePeriod: 22,
-        barcodeValue: 12,
-        isNest: false,
-        incompatibleFlower: false
+        ...commonInteractionData
       }));
       await firebase.assertFails(addInteraction(carol, round.path, {
         userId: 'bob',
-        timePeriod: 22,
-        barcodeValue: 12,
-        isNest: false,
-        incompatibleFlower: false
+        ...commonInteractionData
       }));
     });
 
     it('cannot be deleted by anyone', async () => {
       const doc = await addInteraction(admin, round.path, {
         userId: 'bob',
-        timePeriod: 22,
-        barcodeValue: 12,
-        isNest: false,
-        incompatibleFlower: false
+        ...commonInteractionData
       });
       await firebase.assertFails(alice.doc(doc.path).delete());
       await firebase.assertFails(bob.doc(doc.path).delete());
@@ -229,10 +205,7 @@ describe('Rounds', () => {
     it('cannot be updated by anyone', async () => {
       const doc = await addInteraction(admin, round.path, {
         userId: 'bob',
-        timePeriod: 22,
-        barcodeValue: 12,
-        isNest: false,
-        incompatibleFlower: false
+        ...commonInteractionData
       });
       await firebase.assertFails(alice.doc(doc.path).update({timePeriod: 23}));
       await firebase.assertFails(bob.doc(doc.path).update({timePeriod: 12}));

--- a/src/app/components/play-round/play-round.component.spec.ts
+++ b/src/app/components/play-round/play-round.component.spec.ts
@@ -25,7 +25,7 @@ describe('PlayRoundComponent', () => {
   beforeEach(() => {
     mockSessionStudentData$ = new BehaviorSubject(null);
     mockCurrentFlowers$ = new BehaviorSubject([]);
-    mockBeeSpecies$ = new BehaviorSubject(null);
+    mockBeeSpecies$ = new BehaviorSubject(allBeeSpecies.apis_mellifera);
     mockBeePollen$ = new BehaviorSubject(0);
     mockRecentInteractions$ = new BehaviorSubject([]);
   });
@@ -80,7 +80,6 @@ describe('PlayRoundComponent', () => {
         lastEmittedFlowerMarkers = flowerMarkers;
       });
 
-      mockBeeSpecies$.next(allBeeSpecies.apis_mellifera);
       mockCurrentFlowers$.next([
         new RoundFlower(
           allFlowerSpecies.asclepias_syriaca,
@@ -125,7 +124,6 @@ describe('PlayRoundComponent', () => {
         lastEmittedFlowerMarkers = flowerMarkers;
       });
 
-      mockBeeSpecies$.next(allBeeSpecies.apis_mellifera);
       mockCurrentFlowers$.next([
         new RoundFlower(
           allFlowerSpecies.asclepias_syriaca,
@@ -165,7 +163,6 @@ describe('PlayRoundComponent', () => {
           lastEmittedFlowerMarkers = flowerMarkers;
         });
 
-        mockBeeSpecies$.next(allBeeSpecies.apis_mellifera);
         mockCurrentFlowers$.next([
           new RoundFlower(
             allFlowerSpecies.asclepias_syriaca,
@@ -194,7 +191,6 @@ describe('PlayRoundComponent', () => {
           lastEmittedFlowerMarkers = flowerMarkers;
         });
 
-        mockBeeSpecies$.next(allBeeSpecies.apis_mellifera);
         mockCurrentFlowers$.next([
           new RoundFlower(
             allFlowerSpecies.asclepias_syriaca,
@@ -224,7 +220,6 @@ describe('PlayRoundComponent', () => {
           lastEmittedNestMarker = nestMarker;
         });
 
-        mockBeeSpecies$.next(allBeeSpecies.apis_mellifera);
         mockSessionStudentData$.next({ name: 'Fred', nestBarcode: 30 });
 
         tick(0);
@@ -258,7 +253,6 @@ describe('PlayRoundComponent', () => {
         emittedNestMarkers.push(nestMarker);
       });
 
-      mockBeeSpecies$.next(allBeeSpecies.apis_mellifera);
       mockSessionStudentData$.next({ name: 'Fred', nestBarcode: 30 });
       tick(0);
 
@@ -278,7 +272,6 @@ describe('PlayRoundComponent', () => {
         emittedNestMarkers.push(nestMarker);
       });
 
-      mockBeeSpecies$.next(allBeeSpecies.apis_mellifera);
       mockSessionStudentData$.next({ name: 'Fred', nestBarcode: 30 });
       tick(0);
 
@@ -299,7 +292,6 @@ describe('PlayRoundComponent', () => {
         emittedNestMarkers.push(nestMarker);
       });
 
-      mockBeeSpecies$.next(allBeeSpecies.apis_mellifera);
       mockSessionStudentData$.next({ name: 'Fred', nestBarcode: 30 });
       tick(0);
 
@@ -318,7 +310,6 @@ describe('PlayRoundComponent', () => {
         emittedNestMarkers.push(nestMarker);
       });
 
-      mockBeeSpecies$.next(allBeeSpecies.apis_mellifera);
       mockSessionStudentData$.next({ name: 'Fred', nestBarcode: 30 });
       tick(0);
 
@@ -337,7 +328,6 @@ describe('PlayRoundComponent', () => {
         emittedNestMarkers.push(nestMarker);
       });
 
-      mockBeeSpecies$.next(allBeeSpecies.apis_mellifera);
       mockSessionStudentData$.next({ name: 'Fred', nestBarcode: 30 });
       tick(0);
 

--- a/src/app/components/play-round/play-round.component.spec.ts
+++ b/src/app/components/play-round/play-round.component.spec.ts
@@ -69,6 +69,7 @@ describe('PlayRoundComponent', () => {
         userId: 'me',
         barcodeValue,
         isNest: false,
+        incompatibleFlower: false
       };
     }
 

--- a/src/app/components/play-round/play-round.component.spec.ts
+++ b/src/app/components/play-round/play-round.component.spec.ts
@@ -102,6 +102,7 @@ describe('PlayRoundComponent', () => {
         ['isNest', false],
         ['barcodeValue', 1],
         ['canVisit', true],
+        ['incompatibleFlower', false]
       ];
 
       for (const [field, expectedValue] of expectedFields) {
@@ -142,6 +143,7 @@ describe('PlayRoundComponent', () => {
         ['isNest', false],
         ['barcodeValue', 1],
         ['canVisit', false],
+        ['incompatibleFlower', false]
       ];
 
       for (const [field, expectedValue] of expectedFields) {
@@ -242,9 +244,10 @@ describe('PlayRoundComponent', () => {
 
         expect(lastEmittedNestMarker.imgPath).toMatch(/square/);
 
-        // Nest markers don't have an `isBlooming` field; that's only for
-        // flowers.
+        // Nest markers don't have an `isBlooming` or 'incompatibleFlower' field;
+        // that's only for flowers.
         expect('isBlooming' in lastEmittedNestMarker).toBe(false);
+        expect('incompatibleFlower' in lastEmittedNestMarker).toBe(false);
       }),
     );
 

--- a/src/app/components/play-round/play-round.component.spec.ts
+++ b/src/app/components/play-round/play-round.component.spec.ts
@@ -79,6 +79,7 @@ describe('PlayRoundComponent', () => {
         lastEmittedFlowerMarkers = flowerMarkers;
       });
 
+      mockBeeSpecies$.next(allBeeSpecies.apis_mellifera);
       mockCurrentFlowers$.next([
         new RoundFlower(
           allFlowerSpecies.asclepias_syriaca,
@@ -122,6 +123,7 @@ describe('PlayRoundComponent', () => {
         lastEmittedFlowerMarkers = flowerMarkers;
       });
 
+      mockBeeSpecies$.next(allBeeSpecies.apis_mellifera);
       mockCurrentFlowers$.next([
         new RoundFlower(
           allFlowerSpecies.asclepias_syriaca,
@@ -160,6 +162,7 @@ describe('PlayRoundComponent', () => {
           lastEmittedFlowerMarkers = flowerMarkers;
         });
 
+        mockBeeSpecies$.next(allBeeSpecies.apis_mellifera);
         mockCurrentFlowers$.next([
           new RoundFlower(
             allFlowerSpecies.asclepias_syriaca,
@@ -188,6 +191,7 @@ describe('PlayRoundComponent', () => {
           lastEmittedFlowerMarkers = flowerMarkers;
         });
 
+        mockBeeSpecies$.next(allBeeSpecies.apis_mellifera);
         mockCurrentFlowers$.next([
           new RoundFlower(
             allFlowerSpecies.asclepias_syriaca,

--- a/src/app/components/play-round/play-round.component.ts
+++ b/src/app/components/play-round/play-round.component.ts
@@ -16,17 +16,20 @@ import { DomSanitizer } from '@angular/platform-browser';
 })
 export class PlayRoundComponent implements OnInit {
   flowerArMarkers$: Observable<RoundMarker[]> = combineLatest([
+    this.studentRoundService.currentBeeSpecies$,
     this.studentRoundService.currentFlowers$,
     this.studentRoundService.currentBeePollen$,
     this.studentRoundService.recentFlowerInteractions$,
   ]).pipe(
-    map(([flowers, beePollen, recentInteractions]) =>
+    filter(([bee]) => !!bee),
+    map(([bee, flowers, beePollen, recentInteractions]) =>
       flowers.map((flower, index) =>
         roundMarkerFromRoundFlower(
           flower,
           index + 1,
           beePollen,
           recentInteractions,
+          !bee.flowers_accepted.map(acceptedFlower => acceptedFlower.id).includes(flower.species.id)
         )
       )
     )

--- a/src/app/components/play-round/play-round.component.ts
+++ b/src/app/components/play-round/play-round.component.ts
@@ -21,7 +21,6 @@ export class PlayRoundComponent implements OnInit {
     this.studentRoundService.currentBeePollen$,
     this.studentRoundService.recentFlowerInteractions$,
   ]).pipe(
-    filter(([bee]) => !!bee),
     map(([bee, flowers, beePollen, recentInteractions]) =>
       flowers.map((flower, index) =>
         roundMarkerFromRoundFlower(

--- a/src/app/components/play-round/play-round.component.ts
+++ b/src/app/components/play-round/play-round.component.ts
@@ -29,7 +29,7 @@ export class PlayRoundComponent implements OnInit {
           index + 1,
           beePollen,
           recentInteractions,
-          !bee.flowers_accepted.map(acceptedFlower => acceptedFlower.id).includes(flower.species.id)
+          bee
         )
       )
     )

--- a/src/app/components/play-round/play-round.component.ts
+++ b/src/app/components/play-round/play-round.component.ts
@@ -111,7 +111,7 @@ export class PlayRoundComponent implements OnInit {
   }
 
   clickInteract(marker: RoundMarker) {
-    this.studentRoundService.interact(marker.barcodeValue, marker.isNest);
+    this.studentRoundService.interact(marker.barcodeValue, marker.isNest, marker.incompatibleFlower ?? false);
   }
 
   calculateBeeScale(scale: number) {

--- a/src/app/markers.ts
+++ b/src/app/markers.ts
@@ -1,3 +1,4 @@
+import { BeeSpecies } from './bees';
 import { RoundFlower, Interaction } from './round';
 
 /**
@@ -59,9 +60,14 @@ export function roundMarkerFromRoundFlower(
   barcodeValue: number,
   currentBeePollen: number,
   recentFlowerInteractions: Interaction[],
-  incompatibleFlower: boolean
+  bee: BeeSpecies
 ): RoundMarker {
-  const lastVisitedIncompatible = recentFlowerInteractions[0]?.incompatibleFlower && recentFlowerInteractions[0]?.barcodeValue === barcodeValue
+  const incompatibleFlower = !bee.flowers_accepted.map(acceptedFlower =>
+    acceptedFlower.id).includes(flower.species.id);
+
+  const lastVisitedIncompatible = recentFlowerInteractions[0]?.incompatibleFlower &&
+    recentFlowerInteractions[0]?.barcodeValue === barcodeValue;
+
   const canVisit = !lastVisitedIncompatible && canVisitFlower(
     barcodeValue,
     flower.isBlooming,

--- a/src/app/markers.ts
+++ b/src/app/markers.ts
@@ -61,7 +61,7 @@ export function roundMarkerFromRoundFlower(
   recentFlowerInteractions: Interaction[],
   incompatibleFlower: boolean
 ): RoundMarker {
-  const lastVisitedIncompatible = visitingIncompatible(barcodeValue, recentFlowerInteractions);
+  const lastVisitedIncompatible = recentFlowerInteractions[0]?.incompatibleFlower && recentFlowerInteractions[0]?.barcodeValue === barcodeValue
   const canVisit = !lastVisitedIncompatible && canVisitFlower(
     barcodeValue,
     flower.isBlooming,
@@ -78,11 +78,6 @@ export function roundMarkerFromRoundFlower(
     incompatibleFlower,
     tip: lastVisitedIncompatible ? 'I don\'t like this flower. No Pollen collected' : null
   };
-}
-
-
-export function visitingIncompatible(currentBarcode: number, interactions: Interaction[]) {
-  return((interactions[0]?.barcodeValue === currentBarcode && interactions[0].incompatibleFlower) ?? false);
 }
 
 /**

--- a/src/app/markers.ts
+++ b/src/app/markers.ts
@@ -61,7 +61,8 @@ export function roundMarkerFromRoundFlower(
   recentFlowerInteractions: Interaction[],
   incompatibleFlower: boolean
 ): RoundMarker {
-  const canVisit = canVisitFlower(
+  const lastVisitedIncompatible = visitingIncompatible(barcodeValue, recentFlowerInteractions);
+  const canVisit = !lastVisitedIncompatible && canVisitFlower(
     barcodeValue,
     flower.isBlooming,
     currentBeePollen,
@@ -74,8 +75,14 @@ export function roundMarkerFromRoundFlower(
     isBlooming: flower.isBlooming,
     isNest: false,
     canVisit,
-    incompatibleFlower
+    incompatibleFlower,
+    tip: lastVisitedIncompatible ? 'I don\'t like this flower. No Pollen collected' : null
   };
+}
+
+
+export function visitingIncompatible(currentBarcode: number, interactions: Interaction[]) {
+  return((interactions[0]?.barcodeValue === currentBarcode && interactions[0].incompatibleFlower) ?? false);
 }
 
 /**
@@ -92,6 +99,7 @@ export function canVisitFlower(
   recentFlowerInteractions: Interaction[],
 ): boolean {
   const haveVisitedThisFlower = recentFlowerInteractions
+    .filter(interaction => !interaction.incompatibleFlower)
     .map(interaction => interaction.barcodeValue)
     .includes(barcodeValue);
   return isBlooming && currentBeePollen < 3 && !haveVisitedThisFlower;

--- a/src/app/markers.ts
+++ b/src/app/markers.ts
@@ -81,7 +81,7 @@ export function roundMarkerFromRoundFlower(
     isNest: false,
     canVisit,
     incompatibleFlower,
-    tip: lastVisitedIncompatible ? 'I don\'t like this flower. No Pollen collected' : null
+    tip: lastVisitedIncompatible ? `${bee.name}s can't collect pollen from this flower` : null
   };
 }
 

--- a/src/app/markers.ts
+++ b/src/app/markers.ts
@@ -62,8 +62,7 @@ export function roundMarkerFromRoundFlower(
   recentFlowerInteractions: Interaction[],
   bee: BeeSpecies
 ): RoundMarker {
-  const incompatibleFlower = !bee.flowers_accepted.map(acceptedFlower =>
-    acceptedFlower.id).includes(flower.species.id);
+  const incompatibleFlower = !bee.flowers_accepted.map(acceptedFlower => acceptedFlower.id).includes(flower.species.id);
 
   const lastVisitedIncompatible = recentFlowerInteractions[0]?.incompatibleFlower &&
     recentFlowerInteractions[0]?.barcodeValue === barcodeValue;

--- a/src/app/markers.ts
+++ b/src/app/markers.ts
@@ -35,6 +35,11 @@ export interface RoundMarker extends ARMarker {
   // The 'tip' field will only be present if this round marker matches any conditional
   // to display a tip to the students
   tip?: string;
+
+  // This field will only be present on round markers representing flowers.
+  // It will be true or false depending on whether this flower species is
+  // on a bee's 'flowers_accepted' list
+  incompatibleFlower?: boolean
 }
 
 export const MIN_FLOWER_MARKER = 1;
@@ -53,7 +58,8 @@ export function roundMarkerFromRoundFlower(
   flower: RoundFlower,
   barcodeValue: number,
   currentBeePollen: number,
-  recentFlowerInteractions: Interaction[]
+  recentFlowerInteractions: Interaction[],
+  incompatibleFlower: boolean
 ): RoundMarker {
   const canVisit = canVisitFlower(
     barcodeValue,
@@ -68,6 +74,7 @@ export function roundMarkerFromRoundFlower(
     isBlooming: flower.isBlooming,
     isNest: false,
     canVisit,
+    incompatibleFlower
   };
 }
 

--- a/src/app/markers.ts
+++ b/src/app/markers.ts
@@ -39,7 +39,7 @@ export interface RoundMarker extends ARMarker {
   // This field will only be present on round markers representing flowers.
   // It will be true or false depending on whether this flower species is
   // on a bee's 'flowers_accepted' list
-  incompatibleFlower?: boolean
+  incompatibleFlower?: boolean;
 }
 
 export const MIN_FLOWER_MARKER = 1;

--- a/src/app/round.ts
+++ b/src/app/round.ts
@@ -41,6 +41,7 @@ export interface Interaction {
   userId: string;
   barcodeValue: number;
   isNest: boolean;
+  incompatibleFlower: boolean;
 }
 
 /**

--- a/src/app/services/student-round.service.spec.ts
+++ b/src/app/services/student-round.service.spec.ts
@@ -1144,6 +1144,7 @@ describe('StudentRoundService', () => {
         timePeriod: values.rounds.q.currentTime,
         barcodeValue: 5,
         isNest: false,
+        incompatibleFlower: false
       });
 
       interactionSpy.calls.reset();
@@ -1158,6 +1159,7 @@ describe('StudentRoundService', () => {
         timePeriod: values.rounds.r.currentTime,
         barcodeValue: 7,
         isNest: false,
+        incompatibleFlower: false
       });
     }));
 

--- a/src/app/services/student-round.service.ts
+++ b/src/app/services/student-round.service.ts
@@ -232,10 +232,10 @@ export class StudentRoundService {
    * @param barcodeValue the barcode value to submit in the interaction
    * @param isANest whether the barcode corresponds to a student's nest
    */
-  interact(barcodeValue: number, isNest: boolean = false) {
+  interact(barcodeValue: number, isNest: boolean = false, incompatibleFlower: boolean = false) {
     combineLatest([this.sessionService.currentRoundPath$, this.authService.currentUser$, this.currentTime$]).pipe(take(1)).subscribe(
       ([path, user, time]) =>
-      this.firebaseService.addInteraction(path, {userId: user.uid, barcodeValue, isNest, timePeriod: time.time})
+      this.firebaseService.addInteraction(path, {userId: user.uid, barcodeValue, isNest, incompatibleFlower, timePeriod: time.time})
     );
   }
 

--- a/src/app/services/student-round.service.ts
+++ b/src/app/services/student-round.service.ts
@@ -201,7 +201,7 @@ export class StudentRoundService {
 
   totalPollen$: Observable<number> = this.interactions$.pipe(
     map(interactions =>
-      interactions.filter(interaction => !interaction.isNest).length
+      interactions.filter(interaction => (!interaction.isNest && !interaction.incompatibleFlower)).length
     ),
     shareReplay(1),
   );
@@ -213,7 +213,9 @@ export class StudentRoundService {
    * observable will just emit 0.
    */
   currentBeePollen$: Observable<number> = this.recentFlowerInteractions$.pipe(
-    map(recentFlowerInteractions => recentFlowerInteractions.length),
+    map(recentFlowerInteractions =>
+      recentFlowerInteractions.filter(interaction => !interaction.incompatibleFlower).length
+    ),
     distinctUntilChanged(),
     shareReplay(1),
   );


### PR DESCRIPTION
Closes: #191 

- Students (their bees) can interact with any flower, but only collect pollen from compatible flowers
- After interacting with an incompatible flower:

1.  A tip informs the students about their bee's incompatibility with the flower as well as the fact that no pollen was collected.
2. The interact button for that flower is disabled.

- The tip and the disabling of the interaction button stays until a valid interaction is made.