### PR TITLE
Get the GitHub SVG from the right place

### DIFF
--- a/src/app/pages/about/about.component.ts
+++ b/src/app/pages/about/about.component.ts
@@ -1,5 +1,4 @@
 import { Component, OnInit } from '@angular/core';
-import { MatIconRegistry } from '@angular/material/icon';
 import { DomSanitizer } from '@angular/platform-browser';
 import { SwUpdate } from '@angular/service-worker';
 import { buzzAbout as buzzAboutInfo, assets as assetsInfo } from '../../../../project-info.json';
@@ -23,11 +22,7 @@ export class AboutComponent implements OnInit {
     this.assetsContributors.filter(x => !this.buzzAboutContributors.some(y => x.username === y.username))
   );
 
-  constructor(iconRegistry: MatIconRegistry, sanitizer: DomSanitizer, public updates: SwUpdate) {
-    iconRegistry.addSvgIcon(
-      'github',
-      sanitizer.bypassSecurityTrustResourceUrl('assets/github.svg')
-    );
+  constructor(sanitizer: DomSanitizer, public updates: SwUpdate) {
   }
 
   ngOnInit(): void {


### PR DESCRIPTION
We recently changed where the GitHub icon SVG lives. It used to be in the `assets/` directory; now it's in a TS file. (We're statically linking it in with the WebPack bundle.)

Unfortunately, one lingering reference to the `assets/` directory didn't get changed.  (Or, it got changed, and then it got changed back, or something like that.) This commit fixes the issue.

(I also quickly searched through the codebase, and it looks like that was the last reference to storing custom SVG icons in `assets/`.)

Closes  #215.