### PR TITLE
Update footer links on home page

### DIFF
--- a/src/app/pages/about/about.component.html
+++ b/src/app/pages/about/about.component.html
@@ -31,7 +31,7 @@
           Privacy Policy
         </a>
         <div fxFlex></div> -->
-        <a mat-button href="https://github.com/mn-pollinators/buzz-about">
+        <a mat-button href="https://github.com/mn-pollinators/buzz-about" target="_blank" rel="noopener noreferrer">
           <mat-icon svgIcon="github"></mat-icon>
           GitHub Repo
         </a>
@@ -49,7 +49,7 @@
         </p>
       </mat-card-content>
       <mat-card-actions>
-        <a mat-button href="https://github.com/mn-pollinators">
+        <a mat-button href="https://github.com/mn-pollinators" target="_blank" rel="noopener noreferrer">
           <mat-icon svgIcon="github"></mat-icon>
           GitHub
         </a>
@@ -78,7 +78,7 @@
           <p>
             Funding for this project was provided by the Minnesota Environment and Natural Resources Trust Fund
             as recommended by the
-            <a href="https://www.lccmr.leg.mn/">Legislative-Citizen Commission on Minnesota Resources (LCCMR)</a>.
+            <a href="https://www.lccmr.leg.mn/" target="_blank" rel="noopener noreferrer">Legislative-Citizen Commission on Minnesota Resources (LCCMR)</a>.
           </p>
           <p>
             The Trust Fund is a permanent fund constitutionally established by the citizens of Minnesota to assist in the protection,
@@ -97,13 +97,13 @@
       <mat-card-content>
         <p>
           Buzz About is released under the
-          <a href="https://github.com/mn-pollinators/buzz-about/blob/master/LICENSE">MIT License</a>
+          <a href="https://github.com/mn-pollinators/buzz-about/blob/master/LICENSE" target="_blank" rel="noopener noreferrer">MIT License</a>
           except as otherwise noted. The illustrations used in Buzz About are released by Olivia Carlson under
-          <a href="https://creativecommons.org/licenses/by-nc/4.0/">Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)</a>.
+          <a href="https://creativecommons.org/licenses/by-nc/4.0/" target="_blank" rel="noopener noreferrer">Creative Commons Attribution-NonCommercial 4.0 International (CC BY-NC 4.0)</a>.
         </p>
       </mat-card-content>
       <mat-card-actions>
-        <a mat-button href="/3rdpartylicenses.txt">Third-Party Licenses</a>
+        <a mat-button href="/3rdpartylicenses.txt" target="_blank">Third-Party Licenses</a>
       </mat-card-actions>
     </mat-card>
 

--- a/src/app/pages/home/home.component.html
+++ b/src/app/pages/home/home.component.html
@@ -9,13 +9,13 @@
       <mat-card>
         <mat-card-title>Join a session</mat-card-title>
         <mat-card-actions align="end">
-          <button fxFlex mat-raised-button routerLink="/play" color="primary">Play</button>
+          <a fxFlex mat-raised-button routerLink="/play" color="primary">Play</a>
         </mat-card-actions>
       </mat-card>
       <mat-card>
         <mat-card-title>Host a session</mat-card-title>
         <mat-card-actions align="end">
-          <button fxFlex mat-raised-button routerLink="/host" color="accent">Host</button>
+          <a fxFlex mat-raised-button routerLink="/host" color="accent">Host</a>
         </mat-card-actions>
       </mat-card>
     </div>
@@ -23,29 +23,21 @@
   <div class="about-container">
     <mat-card class="about-card">
       <mat-card-content>
-        <span>
-          Buzz About by Minnesota Pollinators
+        <span class="about-buttons">
+          <a mat-button routerLink="/field-guide">Field Guide</a>
+          <a mat-button routerLink="/markers">Markers</a>
         </span>
         <span class="about-buttons" fxHide.xs>
-          <button mat-button routerLink="/field-guide">Field Guide</button>
-          <button mat-button routerLink="/markers">Markers</button>
-          <button mat-button routerLink="/about">About</button>
-          <!-- <button mat-button >Privacy Policy</button> -->
+          <a mat-button routerLink="/about">About</a>
+          <a mat-button href="https://docs.buzzabout.app/privacy-policy" target="_blank">Privacy</a>
         </span>
         <span class="about-buttons" fxHide.gt-xs>
-          <button mat-icon-button [matMenuTriggerFor]="menu">
+          <a mat-icon-button [matMenuTriggerFor]="menu">
             <mat-icon>more_vert</mat-icon>
-          </button>
+          </a>
           <mat-menu #menu="matMenu">
-            <button mat-menu-item routerLink="/field-guide">
-              Field Guide
-            </button>
-            <button mat-menu-item routerLink="/markers">
-              Markers
-            </button>
-            <button mat-menu-item routerLink="/about">
-              About
-            </button>
+            <a mat-menu-item routerLink="/about">About</a>
+            <a mat-menu-item href="https://docs.buzzabout.app/privacy-policy" target="_blank">Privacy</a>
           </mat-menu>
         </span>
       </mat-card-content>

--- a/src/app/pages/home/home.component.scss
+++ b/src/app/pages/home/home.component.scss
@@ -21,10 +21,7 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
-    flex-wrap: nowrap;
-    .about-buttons {
-      white-space: nowrap;
-    }
+    flex-wrap: wrap;
   }
 }
 

--- a/src/app/pages/page-not-found/page-not-found.component.html
+++ b/src/app/pages/page-not-found/page-not-found.component.html
@@ -7,7 +7,7 @@
         Sorry, we couldn't find a page at <code>/{{(route.url | async).join('/')}}</code>.
       </mat-card-content>
       <mat-card-actions align="end">
-        <button mat-button color="primary" routerLink="/">Go Home</button>
+        <a mat-button color="primary" routerLink="/">Go Home</a>
       </mat-card-actions>
     </mat-card>
   </div>


### PR DESCRIPTION
Adds the privacy policy link to the footer on the home page. Also removes the text from the footer and reorganizes the buttons.

![image](https://user-images.githubusercontent.com/1300395/112848950-38e0f000-906e-11eb-90c9-75b30f9fb864.png)

![image](https://user-images.githubusercontent.com/1300395/112849027-47c7a280-906e-11eb-8c92-1a1f18fa904f.png)
