### PR TITLE
Add fix for field guide images in Webkit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2846,7 +2846,8 @@
         },
         "node-fetch": {
           "version": "2.6.0",
-          "resolved": "",
+          "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.0.tgz",
+          "integrity": "sha512-8dG4H5ujfvFiqDmVu9fQ5bOHUC15JMjMY/Zumv26oOvvVJjM67KF8koCWIabKQ1GJIa9r2mMZscBq/TbdOcmNA==",
           "dev": true
         },
         "node-forge": {
@@ -3720,9 +3721,9 @@
       }
     },
     "@mn-pollinators/assets": {
-      "version": "0.6.0",
-      "resolved": "https://npm.pkg.github.com/download/@mn-pollinators/assets/0.6.0/742bdd0815852f679fc16ca757b1fc7692161c6f0f22f449cd551e6a865aa0b4",
-      "integrity": "sha512-nAmwk7aCnzq5xeFnRtjWjvUxHHfBQtkeu+COfFqzKvrZg5qQUheyi2LJ9sFOALW7268p+FzUMWNbyL/tMkdoGQ=="
+      "version": "0.7.0",
+      "resolved": "https://npm.pkg.github.com/download/@mn-pollinators/assets/0.7.0/70cef268c0b7de5b7644f8e15cbbf42e532094a1194935590a446971e1b23881",
+      "integrity": "sha512-odHfNzjE2cgaDRql3J3VkJFQLXDY10lbM7NZ0jgz/CgftLApYDHC6hVKwhi2hbobT1ulIY7HjUtJG+3V90Eu8Q=="
     },
     "@ngneat/until-destroy": {
       "version": "7.3.2",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@angular/platform-browser-dynamic": "~9.1.11",
     "@angular/router": "~9.1.11",
     "@angular/service-worker": "~9.1.11",
-    "@mn-pollinators/assets": "0.6.0",
+    "@mn-pollinators/assets": "0.7.0",
     "@ngneat/until-destroy": "^7.3.2",
     "animejs": "^3.2.1",
     "firebase": ">= 5.5.7 <8",

--- a/src/app/bees.ts
+++ b/src/app/bees.ts
@@ -34,6 +34,7 @@ export interface BeeSpecies {
   sociality: BeeSociality;
   asset_urls: {
     art_500_wide: string;
+    art_512_square: string;
   };
 }
 
@@ -79,7 +80,8 @@ for (const [key, beeFromJson] of Object.entries(allBeesFromJson)) {
     ],
     sociality: BeeSociality[beeFromJson.sociality],
     asset_urls: {
-      art_500_wide: `/assets/art/500w/bees/${beeFromJson.art_file}`
+      art_500_wide: `/assets/art/500w/bees/${beeFromJson.art_file}`,
+      art_512_square: `/assets/art/512-square/bees/${beeFromJson.art_file}`
     }
   };
 }

--- a/src/app/components/field-guide-dialog/field-guide-dialog.component.html
+++ b/src/app/components/field-guide-dialog/field-guide-dialog.component.html
@@ -8,7 +8,10 @@
 
 <div class="description">
   <div class="header-image-container">
-    <img class="header-image" [src]="data.value.asset_urls.art_500_wide">
+    <img *ngIf="!platform.WEBKIT; else webkitFixHeaderImg" class="header-image" [src]="data.value.asset_urls.art_500_wide">
+    <ng-template #webkitFixHeaderImg>
+      <img class="header-image webkit-fix" [src]="data.value.asset_urls.art_512_square">
+    </ng-template>
   </div>
   <div class="active-period" *ngIf="!nest">
     <div class="section-header">{{flower ? 'Blooming Period' : 'Time Active'}}</div>
@@ -33,7 +36,10 @@
     <h3>{{flower ? 'Bees Attracted' : bee ? 'Flowers Preferred' : 'Bee with this Nest'}}</h3>
     <div class="accepted-list">
       <div *ngFor="let item of acceptedList" class="accepted-list-item">
-        <img [src]="item.asset_urls.art_500_wide">
+        <img *ngIf="!platform.WEBKIT; else webkitFixAcceptedImg" [src]="item.asset_urls.art_500_wide">
+        <ng-template #webkitFixAcceptedImg>
+          <img class="webkit-fix" [src]="item.asset_urls.art_512_square">
+        </ng-template>
         <div class="accepted-name">{{item.name | titlecase}}</div>
       </div>
     </div>

--- a/src/app/components/field-guide-dialog/field-guide-dialog.component.scss
+++ b/src/app/components/field-guide-dialog/field-guide-dialog.component.scss
@@ -111,8 +111,6 @@
   margin-top: 16px;
 }
 
-.section-heade
-
-r {
+.section-header {
   @include mat-typography-level-to-styles($typography-config, subheading-2);
 }

--- a/src/app/components/field-guide-dialog/field-guide-dialog.component.scss
+++ b/src/app/components/field-guide-dialog/field-guide-dialog.component.scss
@@ -33,6 +33,13 @@
     display: block;
     max-height: 152px;
     max-width: 100%;
+
+    &.webkit-fix {
+      // Necessary for Safari. Otherwise we get this bug:
+      // https://github.com/mn-pollinators/buzz-about/issues/257
+      width: 152px;
+      height: 152px;
+    }
   }
 }
 
@@ -61,6 +68,12 @@
       margin-right: auto;
       height: 56px;
       margin-bottom: 4px;
+
+      &.webkit-fix {
+        // Necessary for Safari. Otherwise we get this bug:
+        // https://github.com/mn-pollinators/buzz-about/issues/257
+        width: 56px;
+      }
     }
     .accepted-name {
       text-align: center;
@@ -98,6 +111,8 @@
   margin-top: 16px;
 }
 
-.section-header {
+.section-heade
+
+r {
   @include mat-typography-level-to-styles($typography-config, subheading-2);
 }

--- a/src/app/components/field-guide-dialog/field-guide-dialog.component.ts
+++ b/src/app/components/field-guide-dialog/field-guide-dialog.component.ts
@@ -57,7 +57,6 @@ export class FieldGuideDialogComponent implements OnInit {
   acceptedList = this.bee ? this.bee.flowers_accepted : this.flower ? getBeesForFlower(this.flower) : getBeesForNest(this.nest);
 
   ngOnInit(): void {
-    console.log(this.platform)
   }
 
 }

--- a/src/app/components/field-guide-dialog/field-guide-dialog.component.ts
+++ b/src/app/components/field-guide-dialog/field-guide-dialog.component.ts
@@ -1,3 +1,4 @@
+import { Platform } from '@angular/cdk/platform';
 import { ChangeDetectionStrategy, Component, Inject, OnInit } from '@angular/core';
 import { MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { beeDescriptionKeys, BeeSpecies, getBeesForFlower, getBeesForNest } from 'src/app/bees';
@@ -24,7 +25,7 @@ export type FieldGuideDialogData = {
 })
 export class FieldGuideDialogComponent implements OnInit {
 
-  constructor(@Inject(MAT_DIALOG_DATA) public data: FieldGuideDialogData) {
+  constructor(@Inject(MAT_DIALOG_DATA) public data: FieldGuideDialogData, public platform: Platform) {
 
   }
 
@@ -56,6 +57,7 @@ export class FieldGuideDialogComponent implements OnInit {
   acceptedList = this.bee ? this.bee.flowers_accepted : this.flower ? getBeesForFlower(this.flower) : getBeesForNest(this.nest);
 
   ngOnInit(): void {
+    console.log(this.platform)
   }
 
 }

--- a/src/app/shared.module.ts
+++ b/src/app/shared.module.ts
@@ -20,6 +20,8 @@ import { FlexLayoutModule } from '@angular/flex-layout';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { HttpClientModule } from '@angular/common/http';
 import { NgPipesModule } from 'ngx-pipes';
+import { RouterModule } from '@angular/router';
+import { PlatformModule } from '@angular/cdk/platform';
 
 import { FullscreenButtonComponent } from './components/fullscreen-button/fullscreen-button.component';
 import { HillBackgroundComponent } from './components/hill-background/hill-background.component';
@@ -29,7 +31,7 @@ import { PollenIndicatorComponent } from './components/pollen-indicator/pollen-i
 import { FieldGuideDialogComponent } from './components/field-guide-dialog/field-guide-dialog.component';
 import { SmallTimelineComponent } from './components/small-timeline/small-timeline.component';
 import { FieldGuideComponent } from './pages/field-guide/field-guide.component';
-import { RouterModule } from '@angular/router';
+
 
 
 
@@ -58,6 +60,7 @@ const sharedImportModules = [
   ReactiveFormsModule,
   HttpClientModule,
   NgPipesModule,
+  PlatformModule,
 ];
 
 const sharedComponents = [


### PR DESCRIPTION
This is a (hopefully temporary) fix for the issue we were having where images wouldn't display in the field guide dialog in Webkit (Safari). We now replace the images in the field guide dialog with the 512 square versions only on Webkit so we can set a default width/height for those.